### PR TITLE
atButtons Flat Fix

### DIFF
--- a/atflatcontrols/atbuttons.pas
+++ b/atflatcontrols/atbuttons.pas
@@ -241,8 +241,19 @@ begin
   if Assigned(FOnMouseEnter) then FOnMouseEnter(Self);
 end;
 
+type
+  TControlCracker = class(TControl);
 procedure TATButton.DoMouseLeave;
 begin
+  if FFlat then
+  begin
+    if Parent <> nil then
+    if Parent is TControl then
+    begin
+      Self.Canvas.Brush.Color:= TControlCracker(Parent).Color;
+      Self.Canvas.FillRect(Self.Canvas.ClipRect);
+    end;
+  end;
   FOver:= false;
   Invalidate;
   if Assigned(FOnMouseLeave) then FOnMouseLeave(Self);


### PR DESCRIPTION
atButtons Flat Fix: OK, this one works without touching the paint code. It's a change in the TATButton.DoMouseLeave proc. See if this will work, I'd really like to use the buttons but until we get a fix for flat I can't use them!