### PR TITLE
atButtons flat fix 2

### DIFF
--- a/atflatcontrols/atbuttons.pas
+++ b/atflatcontrols/atbuttons.pas
@@ -241,19 +241,8 @@ begin
   if Assigned(FOnMouseEnter) then FOnMouseEnter(Self);
 end;
 
-type
-  TControlCracker = class(TControl);
 procedure TATButton.DoMouseLeave;
 begin
-  if FFlat then
-  begin
-    if Parent <> nil then
-    if Parent is TControl then
-    begin
-      Self.Canvas.Brush.Color:= TControlCracker(Parent).Color;
-      Self.Canvas.FillRect(Self.Canvas.ClipRect);
-    end;
-  end;
   FOver:= false;
   Invalidate;
   if Assigned(FOnMouseLeave) then FOnMouseLeave(Self);
@@ -380,6 +369,8 @@ begin
   PaintTo(Canvas);
 end;
 
+type
+  TControlCracker = class(TControl);
 procedure TATButton.PaintTo(C: TCanvas);
 var
   NWidth, NHeight: integer;
@@ -425,8 +416,20 @@ begin
     C.FillRect(RectAll);
   end
   else
-  //Flat style - don't paint any background
+  begin
+    {$ifdef FPC}
+    //Flat style - don't paint any background (FPC)
     NColorBg:= clNone;
+    {$else}
+    //Flat style - don't paint any background (delphi)
+    if Parent <> nil then
+    if Parent is TControl then
+    begin
+      Self.Canvas.Brush.Color:= TControlCracker(Parent).Color;
+      Self.Canvas.FillRect(Self.Canvas.ClipRect);
+    end;
+    {$endif}
+  end;
 
   if bUseBorder then
   begin


### PR DESCRIPTION
atButtons flat fix 2: After thinking on this overnight, I moved the code into the PaintTo but inside a compiler conditional. Logically that's where it should be, and it does not effect the lazarus version. This all comes up for me from time to time since delphi does not always handle clNone like you think it would. It does sometimes, other times it doesn't.