### PR TITLE
Fix for TATListbox.ClientWidth

### DIFF
--- a/atflatcontrols/atlistbox.pas
+++ b/atflatcontrols/atlistbox.pas
@@ -704,7 +704,7 @@ end;
 function TATListbox.ClientWidth: integer;
 begin
   Result:= inherited ClientWidth;
-  if ThemedScrollbar and Scrollbar.Visible then
+  if ThemedScrollbar and FScrollbar.Visible then
     Dec(Result, FScrollbar.Width);
 end;
 

--- a/atflatcontrols/atlistbox.pas
+++ b/atflatcontrols/atlistbox.pas
@@ -704,7 +704,7 @@ end;
 function TATListbox.ClientWidth: integer;
 begin
   Result:= inherited ClientWidth;
-  if ThemedScrollbar then
+  if ThemedScrollbar and Scrollbar.Visible then
     Dec(Result, FScrollbar.Width);
 end;
 


### PR DESCRIPTION
Fix for TATListbox.ClientWidth added checking if themed scrollbar is visible so client area paints correctly if scrollbar is hidden (usually if not enough items in listbox to need scrolling).