### PR TITLE
Fix 2 for erasebgnd

### DIFF
--- a/atflatcontrols/atlistbox.pas
+++ b/atflatcontrols/atlistbox.pas
@@ -670,6 +670,7 @@ procedure TATListbox.WMEraseBkgnd(var Message: TMessage);
 begin
   Message.Result:= 1;
   if Assigned(FScrollbar) then
+  if not MouseInClient then
     FScrollbar.Refresh;
 end;
 {$endif}


### PR DESCRIPTION
Fix 2 for erasebgnd - fscrollbar would disappear when list was clicked. This fixes that and keeps the resize fix as well.